### PR TITLE
Compile webgl IDL to WebGL Context wrapper / typecheck / flowtypes

### DIFF
--- a/glgenerator/.gitignore
+++ b/glgenerator/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+webgl.idl

--- a/glgenerator/README.md
+++ b/glgenerator/README.md
@@ -1,0 +1,11 @@
+# glgenerator
+
+Tool that generate JavaScript from the WebGL IDL.
+
+```
+npm install
+npm run download-idl
+npm run gen-js
+```
+
+will generate `/src/generated/gl.js`.

--- a/glgenerator/genjs.js
+++ b/glgenerator/genjs.js
@@ -1,0 +1,362 @@
+const fs = require("fs");
+const WebIDL2 = require("webidl2");
+
+const uniq = arr => Array.from(new Set(arr));
+
+const idWrapperClass = {
+  genClassBody: () => `
+  _id: number;
+  constructor (id: number) {
+    this._id = id;
+  }
+`,
+  unwrap: (name) => `${name}._id`,
+};
+
+const objWrapperClass = {
+  // TODO generate the exact flow shape.
+  genClassBody: node => `
+${node.members
+  .map(n => `  ${n.name}: ${toFlowType(n.idlType)};`)
+  .join("\n")}
+  constructor (obj: {| ${node.members
+    .map(n => n.name+": "+toFlowType(n.idlType))
+    .join(", ")} |}) {
+    Object.assign(this, obj);
+  }
+`,
+  unwrap: name => name, // the class instance is preserved because it assigned all the obj fields.
+};
+
+const classesExportWhitelist = {
+  WebGLRenderingContext: {},
+  WebGLObject: idWrapperClass,
+  WebGLBuffer: idWrapperClass,
+  WebGLFramebuffer: idWrapperClass,
+  WebGLProgram: idWrapperClass,
+  WebGLRenderbuffer: idWrapperClass,
+  WebGLShader: idWrapperClass,
+  WebGLTexture: idWrapperClass,
+  WebGLUniformLocation: idWrapperClass,
+  WebGLActiveInfo: objWrapperClass,
+  WebGLShaderPrecisionFormat: objWrapperClass,
+};
+
+const instanceofWhitelist = {
+  Float32Array: true,
+  Int32Array: true,
+  ArrayBuffer: true,
+  ArrayBufferView: true,
+};
+
+const typeOfNumbers = {
+  GLsizeiptr: true,
+  GLfloat: true,
+  GLint: true,
+};
+
+const wrapNullable = (idlType, name, code) =>
+  idlType.nullable
+  ? `${name}===null ? null : ${code}`
+  : code;
+
+const unwrapArg = (name, idlType) => {
+  if (idlType.sequence) {
+    const type = idlType.idlType.idlType;
+    // need sequence -> TypedArray conversion
+    if (type === "GLfloat") {
+      return `new Float32Array(${name})`;
+    }
+    else if (type === "GLint" || type === "long") {
+      return `new Int32Array(${name})`;
+    }
+  }
+  const cls = classesExportWhitelist[idlType.idlType];
+  return (
+    cls ?
+    wrapNullable(idlType, name, cls.unwrap(name))
+    : name
+  );
+};
+
+const FlowtypeAlias = {
+  GLenum: "number",
+  GLboolean: "boolean",
+  GLbitfield: "number",
+  GLbyte: "number",
+  GLshort: "number",
+  GLint: "number",
+  GLsizei: "number",
+  GLintptr: "number",
+  GLsizeiptr: "number",
+  GLubyte: "number",
+  GLushort: "number",
+  GLuint: "number",
+  GLfloat: "number",
+  GLclampf: "number",
+  long: "number",
+  DOMString: "string",
+  object: "Object",
+};
+const toFlowType = (idlType) => {
+  let type;
+  if (idlType.sequence) {
+    type = idlType.idlType;
+    type = `Array<${toFlowType(type)}>`;
+  }
+  else {
+    type = idlType.idlType;
+    if (type in FlowtypeAlias) {
+      type = FlowtypeAlias[type];
+    }
+  }
+  return (idlType.nullable ? "?" : "") + type;
+};
+
+const wrapRes = (name, idlType) => {
+  const type = idlType.idlType;
+  const cls = classesExportWhitelist[type];
+  return (
+    cls ?
+    wrapNullable(idlType, name, `new ${type}(${name})`)
+    : name
+  );
+};
+
+const validateArg = (methodName, index, argName, idlType) => {
+  const type = idlType.idlType;
+  const cls = classesExportWhitelist[type];
+  if (cls) {
+    return `if (${argName}!==null && !(${argName} instanceof ${type})) throw new TypeError("Failed to execute '${methodName}' on 'WebGLRenderingContext': parameter ${index+1} is not of type '${type}'.");`;
+  }
+  return "";
+};
+
+const condForType = (name, idlType) => {
+  const type = idlType.idlType;
+  if (idlType.sequence) {
+    return `${name} instanceof Array`;
+  }
+  else {
+    if (type in classesExportWhitelist || type in instanceofWhitelist) {
+      return `${name} instanceof ${type}`;
+    }
+    if (type in typeOfNumbers) {
+      return `typeof ${name} === "number"`;
+    }
+  }
+  console.error(name, idlType);
+  throw new Error("unsupported case in condForType. "+ name+" type="+type);
+};
+
+fs.readFile("webgl.idl", "utf8", (err, data) => {
+  if (err) throw err;
+  const tree = WebIDL2.parse(data);
+
+  const classes = [];
+  const glMethodsByName = {};
+  tree.forEach(node => {
+    if (node.type === "interface" && node.name in classesExportWhitelist) {
+      classes.push(node);
+    }
+    else if (node.type === "interface" && node.name==="WebGLRenderingContextBase") {
+      node.members.forEach(node => {
+        if (node.type === "operation" && !node.static) {
+          glMethodsByName[node.name] = (glMethodsByName[node.name]||[]).concat(node);
+        }
+      });
+    }
+  });
+
+  const glMethodCodes = Object.keys(glMethodsByName).map(name => {
+    let code = `${name} `;
+    const nodes = glMethodsByName[name];
+    if (name.indexOf("is")===0 && nodes[0].arguments.length===1 && nodes[0].arguments[0].idlType.idlType in classesExportWhitelist) {
+      // is* methods are handled on JS side.
+      const node = nodes[0];
+      const arg = node.arguments[0];
+      code += `(${arg.name}) { return ${arg.name} instanceof ${arg.idlType.idlType}; }`;
+    }
+    else {
+      const arities = uniq(nodes.map(n => n.arguments.length)).sort((a, b) => a-b);
+      let argNames;
+      const returnIdlType = nodes[0].idlType;
+      if (nodes.length>1) {
+        const maxArity = Math.max.apply(Math, arities);
+        argNames = [];
+        for (let i=0; i<maxArity; i++) {
+          argNames.push("arg"+i);
+        }
+      }
+      else {
+        argNames = nodes[0].arguments.map(arg => arg.name);
+      }
+
+      // TODO if there is more than one node we should do smart things.
+      // TODO in case of a sequence<> we need to convert to a *32Array
+
+      const returnsVoid = returnIdlType.idlType==="void";
+      const multipleNodes = nodes.length > 1;
+
+      // generate gl call code: validates / execute / wrap & return value
+      code += `(${argNames.join(", ")}) {\n`;
+
+      // in case there are multiple signature, we will guess the signature at runtime
+      if (multipleNodes) {
+        code += `    let signature;\n`;
+        const nodesByArities = new Map();
+        nodes.forEach(node => {
+          const arity = node.arguments.length;
+          nodesByArities.set(arity, (nodesByArities.get(arity)||[]).concat(node));
+        });
+        // start switching by arity
+        code += `    switch (arguments.length) {\n`;
+        nodesByArities.forEach((arityNodes, arity) => {
+          code += `    case ${arity}:\n`;
+          if (arityNodes.length===1) {
+            code += `      signature = ${nodes.indexOf(arityNodes[0])};\n`;
+          }
+          else { // more complex case, we need to guess by argument type
+            const uniqByType = [];
+            for (let i = 0; i < arity; i++) {
+              const arr = [];
+              for (let j = 0; j < arityNodes.length; j++) {
+                const node = arityNodes[j];
+                const arg = node.arguments[i];
+                let exists = false;
+                for (let k = 0; k < arr.length; k++) {
+                  const existingArg = arr[k].arguments[i];
+                  if (existingArg.idlType.idlType === arg.idlType.idlType) {
+                    exists = true;
+                    break;
+                  }
+                }
+                if (!exists) {
+                  arr.push(node);
+                }
+              }
+              uniqByType.push(arr);
+            }
+
+            // in our cases, the first arg that differ is ok to "select" the signature. in more advanced case, we could have more than one...
+            const argWithDiffNodes = uniqByType.find(argNodes => argNodes.length > 1);
+            const argIndex = uniqByType.indexOf(argWithDiffNodes);
+            const argName = argNames[argIndex];
+            argWithDiffNodes.forEach((node, i) => {
+              const signature = nodes.indexOf(node);
+              const argType = node.arguments[argIndex].idlType;
+              code += `      ${i===0 ? "if": "else if"} (${condForType(argName, argType)})\n`
+              code += `        signature = ${signature};\n`;
+            });
+          }
+          code += `      break;\n`;
+        });
+        code += `    }\n`;
+      }
+
+      // the generated validation error messages are ~ consistent with WebGL implementation (tested on Chrome)
+      if (arities.length===1) {
+        const arity = arities[0];
+        if (arity > 0) {
+          code += `    if (arguments.length<${arity}) throw new TypeError("Failed to execute '${name}' on 'WebGLRenderingContext': ${arity} arguments required, but only "+arguments.length+" present.");\n`;
+        }
+      }
+      else {
+        code += `    if ([${arities.join(", ")}].indexOf(arguments.length)===-1) throw new TypeError("Failed to execute '${name}' on 'WebGLRenderingContext': Valid arities are : [${arities.join(", ")}], but "+arguments.length+" provided.");\n`;
+        // TODO in chrome: TypeError: Failed to execute 'texImage2D' on 'WebGLRenderingContext': Valid arities are: [6, 9], but 7 arguments provided.
+      }
+
+      if (multipleNodes) {
+        code += "    switch (signature) {\n";
+      }
+      nodes.forEach((node, i) => {
+        if (multipleNodes) code += `    case ${i}:\n`;
+        const validations = // FIXME we can factorize if the args are identical..
+          node.arguments.map((arg, i) =>
+            validateArg(name, i, argNames[i], arg.idlType)
+          ).filter(str => str);
+        if (validations.length) {
+          code += validations.map(str => "    "+str).join("\n")+"\n";
+        }
+
+        code += `    ${
+          returnsVoid
+          ? "" :
+          "const res = "
+        }gl.${name}(${node.arguments.map((arg, i) =>
+         unwrapArg(argNames[i], arg.idlType)
+       ).join(", ")});\n`;
+
+        // generate returns code.
+        if (!returnsVoid) {
+          code += `    return ${wrapRes("res", returnIdlType)};\n`;
+        }
+        else {
+          if (multipleNodes) {
+            code += `    break;\n`;
+          }
+        }
+      });
+      if (multipleNodes) {
+        code += "   }\n";
+      }
+      code += "  }";
+    }
+    return code;
+  });
+
+  console.log("//@flow");
+  console.log("/* eslint-disable */");
+
+  // fake ArrayBufferView class
+  // FIXME it doesn't exist right?
+  console.log("class ArrayBufferView {}");
+
+  // generate classes
+  console.log(classes.map(node => {
+    const cls = classesExportWhitelist[node.name];
+    const inherit = node.inheritance;
+    return `class ${node.name}${inherit ? " extends "+inherit : ""} {${
+        inherit || !cls.genClassBody
+        ? "" // if we inherits, it means we already have the body (in our GL cases)
+        : " " + cls.genClassBody(node) + " "
+      }}`;
+  }).join("\n")+"\n");
+
+  // export classes to global
+  console.log(classes.map(node => {
+    return `global.${node.name} = ${node.name};`;
+  }).join("\n")+"\n");
+
+  // generate Context flow type
+  // TODO: we should generate Context directly in the WebGLRenderingContext class. that way we can also gen the statics.
+  console.log(`
+type TexImageSource = any; // FIXME: to be defined.
+type WebGLContextAttributes = void; // not supported yet
+type BufferDataSource = ArrayBuffer | ArrayBufferView;
+type VertexAttribFVSource = Float32Array | Array<number>;
+type Context = {
+${Object.keys(glMethodsByName).map(name => {
+  return glMethodsByName[name].map(node =>
+    `  ${name}: (${node.arguments.map(arg => arg.name+": "+toFlowType(arg.idlType)).join(", ")}) => ${toFlowType(node.idlType)};`
+  ).join("\n");
+}).join("\n")}
+}
+  `);
+
+  // generate makeGL function
+  // TODO: instead of setPrototypeOf, we should probably `new WebGLRenderingContext()`
+  console.log(`export default (gl: any): Context => {
+  const context: Context = {
+    ...gl,
+${glMethodCodes.map(code => "  "+code).join(",\n")}
+  };
+  if (Object.setPrototypeOf) {
+    Object.setPrototypeOf(context, global.WebGLRenderingContext.prototype);
+  } else {
+    // $FlowFixMe
+    context.__proto__ = global.WebGLRenderingContext.prototype;
+  }
+  return context;
+};`);
+});

--- a/glgenerator/package.json
+++ b/glgenerator/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "glgenerator",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "download-idl": "wget https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl",
+    "gen-js": "node genjs.js 1> ../src/generated/gl.js"
+  },
+  "author": "Gaëtan Renaudeau",
+  "license": "ISC",
+  "dependencies": {
+    "webidl2": "^2.0.11"
+  }
+}

--- a/src/GLView.js
+++ b/src/GLView.js
@@ -44,9 +44,57 @@ export default class GLView extends React.Component {
   });
 }
 
-
 // Class of `gl` objects
-global.WebGLRenderingContext = class { };
+class WebGLRenderingContext {};
+
+class WebGLObject {
+  constructor (id) {
+    this._id = id;
+  }
+}
+class WebGLBuffer extends WebGLObject {}
+class WebGLFramebuffer extends WebGLObject {}
+class WebGLProgram extends WebGLObject {}
+class WebGLRenderbuffer extends WebGLObject {}
+class WebGLShader extends WebGLObject {}
+class WebGLTexture extends WebGLObject {}
+class WebGLUniformLocation {
+  constructor (id) {
+    this._id = id;
+  }
+}
+class WebGLActiveInfo {
+  constructor (obj) {
+    Object.assign(this, obj);
+  }
+}
+class WebGLShaderPrecisionFormat {
+  constructor (obj) {
+    Object.assign(this, obj);
+  }
+}
+
+const unwrap = obj => obj ? obj._id : obj;
+
+const isBuffer = buffer => buffer instanceof WebGLBuffer;
+const isFramebuffer = framebuffer => framebuffer instanceof WebGLFramebuffer;
+const isProgram = program => program instanceof WebGLProgram;
+const isRenderbuffer = renderbuffer => renderbuffer instanceof WebGLRenderbuffer;
+const isShader = shader => shader instanceof WebGLShader;
+const isTexture = texture => texture instanceof WebGLTexture;
+
+// Expose to global, like in WebGL
+global.WebGLRenderingContext = WebGLRenderingContext;
+global.WebGLObject = WebGLObject;
+global.WebGLBuffer = WebGLBuffer;
+global.WebGLFramebuffer = WebGLFramebuffer;
+global.WebGLProgram = WebGLProgram;
+global.WebGLRenderbuffer = WebGLRenderbuffer;
+global.WebGLShader = WebGLShader;
+global.WebGLTexture = WebGLTexture;
+global.WebGLUniformLocation = WebGLUniformLocation;
+global.WebGLActiveInfo = WebGLActiveInfo;
+global.WebGLShaderPrecisionFormat = WebGLShaderPrecisionFormat;
 
 // Get the GL interface from an EXGLContextID and do JS-side setup
 const getGl = (exglCtxId) => {
@@ -61,19 +109,243 @@ const getGl = (exglCtxId) => {
   // No canvas yet...
   gl.canvas = null;
 
-  // Functions that need sequence -> TypedArray conversion
+  // FIXME: greweb note: maybe shouldn't override the methods, but just keep the original rawGL
+  // we would never have to keep reusing the "original" methods and it would make JS faster.
+  // that means returning a new object at the end and not the __EXGLContexts instance.
+  // it would probably help for more easily having Flowtype working.
+  // would also be great to throw exception if args are invalid. consistently with WebGL.
+
+  // following ordering of spec: https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl
+
+  const originalAttachShader = gl.attachShader;
+  gl.attachShader = (program, shader) => {
+    originalAttachShader.call(gl, unwrap(program), unwrap(shader));
+  };
+
+  const originalBindAttribLocation = gl.bindAttribLocation;
+  gl.bindAttribLocation = (program, index, name) => {
+    originalBindAttribLocation.call(gl, unwrap(program), index, name);
+  };
+
+  const originalBindBuffer = gl.bindBuffer;
+  gl.bindBuffer = (target, buffer) => {
+    originalBindBuffer.call(gl, target, unwrap(buffer));
+  };
+
+  const originalBindFramebuffer = gl.bindFramebuffer;
+  gl.bindFramebuffer = (target, framebuffer) => {
+    originalBindFramebuffer.call(gl, target, unwrap(framebuffer));
+  };
+
+  const originalBindRenderbuffer = gl.bindRenderbuffer;
+  gl.bindRenderbuffer = (target, renderbuffer) => {
+    originalBindRenderbuffer.call(gl, target, unwrap(renderbuffer));
+  };
+
+  const originalBindTexture = gl.bindTexture;
+  gl.bindTexture = (target, texture) => {
+    originalBindTexture.call(gl, target, unwrap(texture));
+  };
+
+  const originalCompileShader = gl.compileShader;
+  gl.compileShader = (shader) => {
+    originalCompileShader.call(gl, unwrap(shader));
+  };
+
+  // create functions
+
+  const originalCreateBuffer = gl.createBuffer;
+  gl.createBuffer = () => {
+    const res = originalCreateBuffer.call(gl);
+    return res!==null ? new WebGLBuffer(res) : res;
+  };
+
+  const originalCreateFramebuffer = gl.createFramebuffer;
+  gl.createFramebuffer = () => {
+    const res = originalCreateFramebuffer.call(gl);
+    return res!==null ? new WebGLFramebuffer(res) : res;
+  };
+
+  const originalCreateProgram = gl.createProgram;
+  gl.createProgram = () => {
+    const res = originalCreateProgram.call(gl);
+    return res!==null ? new WebGLProgram(res) : res;
+  };
+
+  const originalCreateRenderbuffer = gl.createRenderbuffer;
+  gl.createRenderbuffer = () => {
+    const res = originalCreateRenderbuffer.call(gl);
+    return res!==null ? new WebGLRenderbuffer(res) : res;
+  };
+  const originalCreateShader = gl.createShader;
+  gl.createShader = (type) => {
+    const res = originalCreateShader.call(gl, type);
+    return res!==null ? new WebGLShader(res) : res;
+  };
+
+  const originalCreateTexture = gl.createTexture;
+  gl.createTexture = () => {
+    const res = originalCreateTexture.call(gl);
+    return res!==null ? new WebGLTexture(res) : res;
+  };
+
+  // delete functions
+
+  const originalDeleteBuffer = gl.deleteBuffer;
+  gl.deleteBuffer = (buffer) => {
+    originalDeleteBuffer.call(gl, unwrap(buffer));
+  };
+
+  const originalDeleteFramebuffer = gl.deleteFramebuffer;
+  gl.deleteFramebuffer = (framebuffer) => {
+    originalDeleteFramebuffer.call(gl, unwrap(framebuffer));
+  };
+
+  const originalDeleteProgram = gl.deleteProgram;
+  gl.deleteProgram = (program) => {
+    originalDeleteProgram.call(gl, unwrap(program));
+  };
+
+  const originalDeleteRenderbuffer = gl.deleteRenderbuffer;
+  gl.deleteRenderbuffer = (renderbuffer) => {
+    originalDeleteRenderbuffer.call(gl, unwrap(renderbuffer));
+  };
+
+  const originalDeleteShader = gl.deleteShader;
+  gl.deleteShader = (shader) => {
+    originalDeleteShader.call(gl, unwrap(shader));
+  };
+
+  const originalDeleteTexture = gl.deleteTexture;
+  gl.deleteTexture = (texture) => {
+    originalDeleteTexture.call(gl, unwrap(texture));
+  };
+
+  const originalDetachShader = gl.detachShader;
+  gl.detachShader = (program, shader) => {
+    originalDetachShader.call(gl, unwrap(program), unwrap(shader));
+  };
+
+  const originalFramebufferRenderbuffer = gl.framebufferRenderbuffer;
+  gl.framebufferRenderbuffer = (target, attachment, renderbuffertarget, renderbuffer) => {
+    originalFramebufferRenderbuffer.call(gl, target, attachment, renderbuffertarget, unwrap(renderbuffer));
+  };
+
+  const originalFramebufferTexture2D = gl.framebufferTexture2D;
+  gl.framebufferTexture2D = (target, attachment, textarget, texture, level) => {
+    originalFramebufferTexture2D.call(gl, target, attachment, textarget, unwrap(texture), level);
+  };
+
+  const originalGetActiveAttrib = gl.getActiveAttrib;
+  gl.getActiveAttrib = (program, index) => {
+    const res = originalGetActiveAttrib.call(gl, unwrap(program), index);
+    return res!==null ? new WebGLActiveInfo(res) : res;
+  };
+
+  const originalGetActiveUniform = gl.getActiveUniform;
+  gl.getActiveUniform = (program, index) => {
+    const res = originalGetActiveUniform.call(gl, unwrap(program), index);
+    return res!==null ? new WebGLActiveInfo(res) : res;
+  };
+
+  const originalGetAttachedShaders = gl.getAttachedShaders;
+  gl.getAttachedShaders = (program) => {
+    const res = originalGetAttachedShaders.call(gl, unwrap(program));
+    return res!==null ? res.map(id => new WebGLShader(id)) : res;
+  };
+
+  const originalGetAttribLocation = gl.getAttribLocation;
+  gl.getAttribLocation = (program, name) =>
+    originalGetAttribLocation.call(gl, unwrap(program), name);
+
+  const originalGetProgramParameter = gl.getProgramParameter;
+  gl.getProgramParameter = (program, pname) =>
+    originalGetProgramParameter.call(gl, unwrap(program), pname);
+
+  const originalGetProgramInfoLog = gl.getProgramInfoLog;
+  gl.getProgramInfoLog = (program) =>
+    originalGetProgramInfoLog.call(gl, unwrap(program));
+
+  const originalGetShaderParameter = gl.getShaderParameter;
+  gl.getShaderParameter = (shader, pname) =>
+    originalGetShaderParameter.call(gl, unwrap(shader), pname);
+
+  const originalGetShaderPrecisionFormat = gl.getShaderPrecisionFormat;
+  gl.getShaderPrecisionFormat = (shadertype, precisiontype) => {
+    const res = originalGetShaderPrecisionFormat.call(gl, shadertype, precisiontype);
+    return res!==null ? new WebGLShaderPrecisionFormat(res) : res;
+  };
+
+  const originalGetShaderInfoLog = gl.getShaderInfoLog;
+  gl.getShaderInfoLog = (shader) =>
+    originalGetShaderInfoLog.call(gl, unwrap(shader));
+
+  const originalGetShaderSource = gl.getShaderSource;
+  gl.getShaderSource = (shader) =>
+    originalGetShaderSource.call(gl, unwrap(shader));
+
+  const originalGetUniform = gl.getUniform;
+  gl.getUniform = (program, location) =>
+    originalGetUniform.call(gl, unwrap(program), unwrap(location));
+
+  const originalGetUniformLocation = gl.getUniformLocation;
+  gl.getUniformLocation = (program, name) => {
+    const res = originalGetUniformLocation.call(gl, unwrap(program), name);
+    return res!==null ? new WebGLUniformLocation(res) : res;
+  };
+
+  gl.isBuffer = isBuffer;
+  gl.isFramebuffer = isFramebuffer;
+  gl.isProgram = isProgram;
+  gl.isRenderbuffer = isRenderbuffer;
+  gl.isShader = isShader;
+  gl.isTexture = isTexture;
+
+  const originalLinkProgram = gl.linkProgram;
+  gl.linkProgram = (program) => {
+    originalLinkProgram.call(gl, unwrap(program));
+  };
+
+  const originalShaderSource = gl.shaderSource;
+  gl.shaderSource = (shader, source) => {
+    originalShaderSource.call(gl, unwrap(shader), source);
+  };
+
+  // Uniform Functions
   [
+    { func: 'uniform1f' },
     { func: 'uniform1fv', arg: 1, type: Float32Array },
+    { func: 'uniform2f' },
     { func: 'uniform2fv', arg: 1, type: Float32Array },
+    { func: 'uniform3f' },
     { func: 'uniform3fv', arg: 1, type: Float32Array },
+    { func: 'uniform4f' },
     { func: 'uniform4fv', arg: 1, type: Float32Array },
+    { func: 'uniform1i' },
     { func: 'uniform1iv', arg: 1, type: Int32Array },
+    { func: 'uniform2i' },
     { func: 'uniform2iv', arg: 1, type: Int32Array },
+    { func: 'uniform3i' },
     { func: 'uniform3iv', arg: 1, type: Int32Array },
+    { func: 'uniform4i' },
     { func: 'uniform4iv', arg: 1, type: Int32Array },
     { func: 'uniformMatrix2fv', arg: 2, type: Float32Array },
     { func: 'uniformMatrix3fv', arg: 2, type: Float32Array },
     { func: 'uniformMatrix4fv', arg: 2, type: Float32Array },
+  ].forEach(({ func, arg, type }) => {
+    const original = gl[func];
+    gl[func] = (...args) => {
+      // NOTE: Keep this fast
+      if (type) { // need sequence -> TypedArray conversion
+        args[arg] = new type(args[arg]);
+      }
+      args[0] = unwrap(args[0]); // the first parameter is always a WebGLUniformLocation
+      return original.apply(gl, args);
+    };
+  });
+
+  // Vertex Functions
+  [
     { func: 'vertexAttrib1fv', arg: 1, type: Float32Array },
     { func: 'vertexAttrib2fv', arg: 1, type: Float32Array },
     { func: 'vertexAttrib3fv', arg: 1, type: Float32Array },
@@ -82,10 +354,22 @@ const getGl = (exglCtxId) => {
     const original = gl[func];
     gl[func] = (...args) => {
       // NOTE: Keep this fast
-      args[arg] = new type(args[arg]);
+      args[arg] = new type(args[arg]); // need sequence -> TypedArray conversion
       return original.apply(gl, args);
     };
   });
+
+  const originalUseProgram = gl.useProgram;
+  gl.useProgram = (program) => {
+    originalUseProgram.call(gl, unwrap(program));
+  };
+
+  const originalValidateProgram = gl.validateProgram;
+  gl.validateProgram = (program) => {
+    originalValidateProgram.call(gl, unwrap(program));
+  };
+
+
 
   // Drawing buffer width/height
   // TODO(nikki): Make this dynamic

--- a/src/GLView.js
+++ b/src/GLView.js
@@ -1,8 +1,9 @@
+// @flow
 'use strict';
 
 import React, { PropTypes } from 'react';
 import { View, requireNativeComponent } from 'react-native';
-
+import fromEXGL from "./generated/gl";
 
 // A component that acts as an OpenGL render target.
 
@@ -44,341 +45,22 @@ export default class GLView extends React.Component {
   });
 }
 
-// Class of `gl` objects
-class WebGLRenderingContext {};
+const enhanceWithLogging = (gl: any): void => {
 
-class WebGLObject {
-  constructor (id) {
-    this._id = id;
-  }
-}
-class WebGLBuffer extends WebGLObject {}
-class WebGLFramebuffer extends WebGLObject {}
-class WebGLProgram extends WebGLObject {}
-class WebGLRenderbuffer extends WebGLObject {}
-class WebGLShader extends WebGLObject {}
-class WebGLTexture extends WebGLObject {}
-class WebGLUniformLocation {
-  constructor (id) {
-    this._id = id;
-  }
-}
-class WebGLActiveInfo {
-  constructor (obj) {
-    Object.assign(this, obj);
-  }
-}
-class WebGLShaderPrecisionFormat {
-  constructor (obj) {
-    Object.assign(this, obj);
-  }
-}
-
-const unwrap = obj => obj ? obj._id : obj;
-
-const isBuffer = buffer => buffer instanceof WebGLBuffer;
-const isFramebuffer = framebuffer => framebuffer instanceof WebGLFramebuffer;
-const isProgram = program => program instanceof WebGLProgram;
-const isRenderbuffer = renderbuffer => renderbuffer instanceof WebGLRenderbuffer;
-const isShader = shader => shader instanceof WebGLShader;
-const isTexture = texture => texture instanceof WebGLTexture;
-
-// Expose to global, like in WebGL
-global.WebGLRenderingContext = WebGLRenderingContext;
-global.WebGLObject = WebGLObject;
-global.WebGLBuffer = WebGLBuffer;
-global.WebGLFramebuffer = WebGLFramebuffer;
-global.WebGLProgram = WebGLProgram;
-global.WebGLRenderbuffer = WebGLRenderbuffer;
-global.WebGLShader = WebGLShader;
-global.WebGLTexture = WebGLTexture;
-global.WebGLUniformLocation = WebGLUniformLocation;
-global.WebGLActiveInfo = WebGLActiveInfo;
-global.WebGLShaderPrecisionFormat = WebGLShaderPrecisionFormat;
-
-// Get the GL interface from an EXGLContextID and do JS-side setup
-const getGl = (exglCtxId) => {
-  const gl = global.__EXGLContexts[exglCtxId];
-  delete global.__EXGLContexts[exglCtxId];
-  if (Object.setPrototypeOf) {
-    Object.setPrototypeOf(gl, global.WebGLRenderingContext.prototype);
-  } else {
-    gl.__proto__ = global.WebGLRenderingContext.prototype;
-  }
-
-  // No canvas yet...
-  gl.canvas = null;
-
-  // FIXME: greweb note: maybe shouldn't override the methods, but just keep the original rawGL
-  // we would never have to keep reusing the "original" methods and it would make JS faster.
-  // that means returning a new object at the end and not the __EXGLContexts instance.
-  // it would probably help for more easily having Flowtype working.
-  // would also be great to throw exception if args are invalid. consistently with WebGL.
-
-  // following ordering of spec: https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl
-
-  const originalAttachShader = gl.attachShader;
-  gl.attachShader = (program, shader) => {
-    originalAttachShader.call(gl, unwrap(program), unwrap(shader));
-  };
-
-  const originalBindAttribLocation = gl.bindAttribLocation;
-  gl.bindAttribLocation = (program, index, name) => {
-    originalBindAttribLocation.call(gl, unwrap(program), index, name);
-  };
-
-  const originalBindBuffer = gl.bindBuffer;
-  gl.bindBuffer = (target, buffer) => {
-    originalBindBuffer.call(gl, target, unwrap(buffer));
-  };
-
-  const originalBindFramebuffer = gl.bindFramebuffer;
-  gl.bindFramebuffer = (target, framebuffer) => {
-    originalBindFramebuffer.call(gl, target, unwrap(framebuffer));
-  };
-
-  const originalBindRenderbuffer = gl.bindRenderbuffer;
-  gl.bindRenderbuffer = (target, renderbuffer) => {
-    originalBindRenderbuffer.call(gl, target, unwrap(renderbuffer));
-  };
-
-  const originalBindTexture = gl.bindTexture;
-  gl.bindTexture = (target, texture) => {
-    originalBindTexture.call(gl, target, unwrap(texture));
-  };
-
-  const originalCompileShader = gl.compileShader;
-  gl.compileShader = (shader) => {
-    originalCompileShader.call(gl, unwrap(shader));
-  };
-
-  // create functions
-
-  const originalCreateBuffer = gl.createBuffer;
-  gl.createBuffer = () => {
-    const res = originalCreateBuffer.call(gl);
-    return res!==null ? new WebGLBuffer(res) : res;
-  };
-
-  const originalCreateFramebuffer = gl.createFramebuffer;
-  gl.createFramebuffer = () => {
-    const res = originalCreateFramebuffer.call(gl);
-    return res!==null ? new WebGLFramebuffer(res) : res;
-  };
-
-  const originalCreateProgram = gl.createProgram;
-  gl.createProgram = () => {
-    const res = originalCreateProgram.call(gl);
-    return res!==null ? new WebGLProgram(res) : res;
-  };
-
-  const originalCreateRenderbuffer = gl.createRenderbuffer;
-  gl.createRenderbuffer = () => {
-    const res = originalCreateRenderbuffer.call(gl);
-    return res!==null ? new WebGLRenderbuffer(res) : res;
-  };
-  const originalCreateShader = gl.createShader;
-  gl.createShader = (type) => {
-    const res = originalCreateShader.call(gl, type);
-    return res!==null ? new WebGLShader(res) : res;
-  };
-
-  const originalCreateTexture = gl.createTexture;
-  gl.createTexture = () => {
-    const res = originalCreateTexture.call(gl);
-    return res!==null ? new WebGLTexture(res) : res;
-  };
-
-  // delete functions
-
-  const originalDeleteBuffer = gl.deleteBuffer;
-  gl.deleteBuffer = (buffer) => {
-    originalDeleteBuffer.call(gl, unwrap(buffer));
-  };
-
-  const originalDeleteFramebuffer = gl.deleteFramebuffer;
-  gl.deleteFramebuffer = (framebuffer) => {
-    originalDeleteFramebuffer.call(gl, unwrap(framebuffer));
-  };
-
-  const originalDeleteProgram = gl.deleteProgram;
-  gl.deleteProgram = (program) => {
-    originalDeleteProgram.call(gl, unwrap(program));
-  };
-
-  const originalDeleteRenderbuffer = gl.deleteRenderbuffer;
-  gl.deleteRenderbuffer = (renderbuffer) => {
-    originalDeleteRenderbuffer.call(gl, unwrap(renderbuffer));
-  };
-
-  const originalDeleteShader = gl.deleteShader;
-  gl.deleteShader = (shader) => {
-    originalDeleteShader.call(gl, unwrap(shader));
-  };
-
-  const originalDeleteTexture = gl.deleteTexture;
-  gl.deleteTexture = (texture) => {
-    originalDeleteTexture.call(gl, unwrap(texture));
-  };
-
-  const originalDetachShader = gl.detachShader;
-  gl.detachShader = (program, shader) => {
-    originalDetachShader.call(gl, unwrap(program), unwrap(shader));
-  };
-
-  const originalFramebufferRenderbuffer = gl.framebufferRenderbuffer;
-  gl.framebufferRenderbuffer = (target, attachment, renderbuffertarget, renderbuffer) => {
-    originalFramebufferRenderbuffer.call(gl, target, attachment, renderbuffertarget, unwrap(renderbuffer));
-  };
-
-  const originalFramebufferTexture2D = gl.framebufferTexture2D;
-  gl.framebufferTexture2D = (target, attachment, textarget, texture, level) => {
-    originalFramebufferTexture2D.call(gl, target, attachment, textarget, unwrap(texture), level);
-  };
-
-  const originalGetActiveAttrib = gl.getActiveAttrib;
-  gl.getActiveAttrib = (program, index) => {
-    const res = originalGetActiveAttrib.call(gl, unwrap(program), index);
-    return res!==null ? new WebGLActiveInfo(res) : res;
-  };
-
-  const originalGetActiveUniform = gl.getActiveUniform;
-  gl.getActiveUniform = (program, index) => {
-    const res = originalGetActiveUniform.call(gl, unwrap(program), index);
-    return res!==null ? new WebGLActiveInfo(res) : res;
-  };
-
-  const originalGetAttachedShaders = gl.getAttachedShaders;
-  gl.getAttachedShaders = (program) => {
-    const res = originalGetAttachedShaders.call(gl, unwrap(program));
-    return res!==null ? res.map(id => new WebGLShader(id)) : res;
-  };
-
-  const originalGetAttribLocation = gl.getAttribLocation;
-  gl.getAttribLocation = (program, name) =>
-    originalGetAttribLocation.call(gl, unwrap(program), name);
-
-  const originalGetProgramParameter = gl.getProgramParameter;
-  gl.getProgramParameter = (program, pname) =>
-    originalGetProgramParameter.call(gl, unwrap(program), pname);
-
-  const originalGetProgramInfoLog = gl.getProgramInfoLog;
-  gl.getProgramInfoLog = (program) =>
-    originalGetProgramInfoLog.call(gl, unwrap(program));
-
-  const originalGetShaderParameter = gl.getShaderParameter;
-  gl.getShaderParameter = (shader, pname) =>
-    originalGetShaderParameter.call(gl, unwrap(shader), pname);
-
-  const originalGetShaderPrecisionFormat = gl.getShaderPrecisionFormat;
-  gl.getShaderPrecisionFormat = (shadertype, precisiontype) => {
-    const res = originalGetShaderPrecisionFormat.call(gl, shadertype, precisiontype);
-    return res!==null ? new WebGLShaderPrecisionFormat(res) : res;
-  };
-
-  const originalGetShaderInfoLog = gl.getShaderInfoLog;
-  gl.getShaderInfoLog = (shader) =>
-    originalGetShaderInfoLog.call(gl, unwrap(shader));
-
-  const originalGetShaderSource = gl.getShaderSource;
-  gl.getShaderSource = (shader) =>
-    originalGetShaderSource.call(gl, unwrap(shader));
-
-  const originalGetUniform = gl.getUniform;
-  gl.getUniform = (program, location) =>
-    originalGetUniform.call(gl, unwrap(program), unwrap(location));
-
-  const originalGetUniformLocation = gl.getUniformLocation;
-  gl.getUniformLocation = (program, name) => {
-    const res = originalGetUniformLocation.call(gl, unwrap(program), name);
-    return res!==null ? new WebGLUniformLocation(res) : res;
-  };
-
-  gl.isBuffer = isBuffer;
-  gl.isFramebuffer = isFramebuffer;
-  gl.isProgram = isProgram;
-  gl.isRenderbuffer = isRenderbuffer;
-  gl.isShader = isShader;
-  gl.isTexture = isTexture;
-
-  const originalLinkProgram = gl.linkProgram;
-  gl.linkProgram = (program) => {
-    originalLinkProgram.call(gl, unwrap(program));
-  };
-
-  const originalShaderSource = gl.shaderSource;
-  gl.shaderSource = (shader, source) => {
-    originalShaderSource.call(gl, unwrap(shader), source);
-  };
-
-  // Uniform Functions
-  [
-    { func: 'uniform1f' },
-    { func: 'uniform1fv', arg: 1, type: Float32Array },
-    { func: 'uniform2f' },
-    { func: 'uniform2fv', arg: 1, type: Float32Array },
-    { func: 'uniform3f' },
-    { func: 'uniform3fv', arg: 1, type: Float32Array },
-    { func: 'uniform4f' },
-    { func: 'uniform4fv', arg: 1, type: Float32Array },
-    { func: 'uniform1i' },
-    { func: 'uniform1iv', arg: 1, type: Int32Array },
-    { func: 'uniform2i' },
-    { func: 'uniform2iv', arg: 1, type: Int32Array },
-    { func: 'uniform3i' },
-    { func: 'uniform3iv', arg: 1, type: Int32Array },
-    { func: 'uniform4i' },
-    { func: 'uniform4iv', arg: 1, type: Int32Array },
-    { func: 'uniformMatrix2fv', arg: 2, type: Float32Array },
-    { func: 'uniformMatrix3fv', arg: 2, type: Float32Array },
-    { func: 'uniformMatrix4fv', arg: 2, type: Float32Array },
-  ].forEach(({ func, arg, type }) => {
-    const original = gl[func];
-    gl[func] = (...args) => {
-      // NOTE: Keep this fast
-      if (type) { // need sequence -> TypedArray conversion
-        args[arg] = new type(args[arg]);
-      }
-      args[0] = unwrap(args[0]); // the first parameter is always a WebGLUniformLocation
-      return original.apply(gl, args);
-    };
-  });
-
-  // Vertex Functions
-  [
-    { func: 'vertexAttrib1fv', arg: 1, type: Float32Array },
-    { func: 'vertexAttrib2fv', arg: 1, type: Float32Array },
-    { func: 'vertexAttrib3fv', arg: 1, type: Float32Array },
-    { func: 'vertexAttrib4fv', arg: 1, type: Float32Array },
-  ].forEach(({ func, arg, type }) => {
-    const original = gl[func];
-    gl[func] = (...args) => {
-      // NOTE: Keep this fast
-      args[arg] = new type(args[arg]); // need sequence -> TypedArray conversion
-      return original.apply(gl, args);
-    };
-  });
-
-  const originalUseProgram = gl.useProgram;
-  gl.useProgram = (program) => {
-    originalUseProgram.call(gl, unwrap(program));
-  };
-
-  const originalValidateProgram = gl.validateProgram;
-  gl.validateProgram = (program) => {
-    originalValidateProgram.call(gl, unwrap(program));
-  };
-
-
-
-  // Drawing buffer width/height
-  // TODO(nikki): Make this dynamic
-  const viewport = gl.getParameter(gl.VIEWPORT);
-  gl.drawingBufferWidth = viewport[2];
-  gl.drawingBufferHeight = viewport[3];
+  const formatObj = obj =>
+  obj instanceof global.WebGLObject || obj instanceof global.WebGLUniformLocation
+  ? '['+obj.constructor.name+' '+obj._id+']'
+  : obj instanceof global.WebGLActiveInfo || obj instanceof global.WebGLShaderPrecisionFormat
+    ? '['+obj.constructor.name+Object.keys(obj).map(key => ` ${key}:${obj[key]}`).join('')+']'
+    : typeof obj === "string"
+      ? '"'+obj+'"'
+      : typeof obj === "object" && obj instanceof Array
+        ? '['+obj.join(',')+']'
+        : String(obj);
 
   // Enable/disable logging of all GL function calls
   let enableLogging = false;
+  // $FlowFixMe
   Object.defineProperty(gl, 'enableLogging', {
     configurable: true,
     get() {
@@ -393,10 +75,16 @@ const getGl = (exglCtxId) => {
           if (typeof gl[key] === 'function') {
             const original = gl[key];
             gl[key] = (...args) => {
-              console.log(`EXGL: ${key}(${args.join(', ')})`);
-              const r = original.apply(gl, args);
-              console.log(`EXGL:    = ${r}`);
-              return r;
+              console.log(`EXGL: ${key}(${args.map(arg => formatObj(arg)).join(', ')})`);
+              try {
+                const r = original.apply(gl, args);
+                console.log(`EXGL: => ${formatObj(r)}`);
+                return r;
+              }
+              catch (e) {
+                console.warn(`EXGL: throws ${e}`);
+                throw e;
+              }
             };
             gl[key].original = original;
           }
@@ -411,6 +99,29 @@ const getGl = (exglCtxId) => {
       enableLogging = enable;
     },
   });
+};
 
+// Get the GL interface from an EXGLContextID and do JS-side setup
+const getGl = (exglCtxId) => {
+  const exgl = global.__EXGLContexts[exglCtxId];
+  delete global.__EXGLContexts[exglCtxId];
+
+  const gl = fromEXGL(exgl);
+
+  // add non standard methods
+  // $FlowFixMe
+  gl.endFrameEXP = () => exgl.endFrameEXP();
+
+  // add fields
+  // $FlowFixMe
+  const viewport = gl.getParameter(gl.VIEWPORT);
+  // $FlowFixMe
+  gl.canvas = null;
+  // $FlowFixMe
+  gl.drawingBufferWidth = viewport[2];
+  // $FlowFixMe
+  gl.drawingBufferHeight = viewport[3];
+
+  if (__DEV__) enhanceWithLogging(gl);
   return gl;
 };

--- a/src/generated/gl.js
+++ b/src/generated/gl.js
@@ -1,0 +1,1061 @@
+//@flow
+/* eslint-disable */
+class ArrayBufferView {}
+class WebGLObject {
+  _id: number;
+  constructor (id: number) {
+    this._id = id;
+  }
+ }
+class WebGLBuffer extends WebGLObject {}
+class WebGLFramebuffer extends WebGLObject {}
+class WebGLProgram extends WebGLObject {}
+class WebGLRenderbuffer extends WebGLObject {}
+class WebGLShader extends WebGLObject {}
+class WebGLTexture extends WebGLObject {}
+class WebGLUniformLocation {
+  _id: number;
+  constructor (id: number) {
+    this._id = id;
+  }
+ }
+class WebGLActiveInfo {
+  size: number;
+  type: number;
+  name: string;
+  constructor (obj: {| size: number, type: number, name: string |}) {
+    Object.assign(this, obj);
+  }
+ }
+class WebGLShaderPrecisionFormat {
+  rangeMin: number;
+  rangeMax: number;
+  precision: number;
+  constructor (obj: {| rangeMin: number, rangeMax: number, precision: number |}) {
+    Object.assign(this, obj);
+  }
+ }
+class WebGLRenderingContext {}
+
+global.WebGLObject = WebGLObject;
+global.WebGLBuffer = WebGLBuffer;
+global.WebGLFramebuffer = WebGLFramebuffer;
+global.WebGLProgram = WebGLProgram;
+global.WebGLRenderbuffer = WebGLRenderbuffer;
+global.WebGLShader = WebGLShader;
+global.WebGLTexture = WebGLTexture;
+global.WebGLUniformLocation = WebGLUniformLocation;
+global.WebGLActiveInfo = WebGLActiveInfo;
+global.WebGLShaderPrecisionFormat = WebGLShaderPrecisionFormat;
+global.WebGLRenderingContext = WebGLRenderingContext;
+
+
+type TexImageSource = any; // FIXME: to be defined.
+type WebGLContextAttributes = void; // not supported yet
+type BufferDataSource = ArrayBuffer | ArrayBufferView;
+type VertexAttribFVSource = Float32Array | Array<number>;
+type Context = {
+  getContextAttributes: () => ?WebGLContextAttributes;
+  isContextLost: () => boolean;
+  getSupportedExtensions: () => ?Array<string>;
+  getExtension: (name: string) => ?Object;
+  activeTexture: (texture: number) => void;
+  attachShader: (program: WebGLProgram, shader: WebGLShader) => void;
+  bindAttribLocation: (program: WebGLProgram, index: number, name: string) => void;
+  bindBuffer: (target: number, buffer: ?WebGLBuffer) => void;
+  bindFramebuffer: (target: number, framebuffer: ?WebGLFramebuffer) => void;
+  bindRenderbuffer: (target: number, renderbuffer: ?WebGLRenderbuffer) => void;
+  bindTexture: (target: number, texture: ?WebGLTexture) => void;
+  blendColor: (red: number, green: number, blue: number, alpha: number) => void;
+  blendEquation: (mode: number) => void;
+  blendEquationSeparate: (modeRGB: number, modeAlpha: number) => void;
+  blendFunc: (sfactor: number, dfactor: number) => void;
+  blendFuncSeparate: (srcRGB: number, dstRGB: number, srcAlpha: number, dstAlpha: number) => void;
+  bufferData: (target: number, size: number, usage: number) => void;
+  bufferData: (target: number, data: ?ArrayBuffer, usage: number) => void;
+  bufferData: (target: number, data: ArrayBufferView, usage: number) => void;
+  bufferSubData: (target: number, offset: number, data: BufferDataSource) => void;
+  checkFramebufferStatus: (target: number) => number;
+  clear: (mask: number) => void;
+  clearColor: (red: number, green: number, blue: number, alpha: number) => void;
+  clearDepth: (depth: number) => void;
+  clearStencil: (s: number) => void;
+  colorMask: (red: boolean, green: boolean, blue: boolean, alpha: boolean) => void;
+  compileShader: (shader: WebGLShader) => void;
+  compressedTexImage2D: (target: number, level: number, internalformat: number, width: number, height: number, border: number, data: ArrayBufferView) => void;
+  compressedTexSubImage2D: (target: number, level: number, xoffset: number, yoffset: number, width: number, height: number, format: number, data: ArrayBufferView) => void;
+  copyTexImage2D: (target: number, level: number, internalformat: number, x: number, y: number, width: number, height: number, border: number) => void;
+  copyTexSubImage2D: (target: number, level: number, xoffset: number, yoffset: number, x: number, y: number, width: number, height: number) => void;
+  createBuffer: () => ?WebGLBuffer;
+  createFramebuffer: () => ?WebGLFramebuffer;
+  createProgram: () => ?WebGLProgram;
+  createRenderbuffer: () => ?WebGLRenderbuffer;
+  createShader: (type: number) => ?WebGLShader;
+  createTexture: () => ?WebGLTexture;
+  cullFace: (mode: number) => void;
+  deleteBuffer: (buffer: ?WebGLBuffer) => void;
+  deleteFramebuffer: (framebuffer: ?WebGLFramebuffer) => void;
+  deleteProgram: (program: ?WebGLProgram) => void;
+  deleteRenderbuffer: (renderbuffer: ?WebGLRenderbuffer) => void;
+  deleteShader: (shader: ?WebGLShader) => void;
+  deleteTexture: (texture: ?WebGLTexture) => void;
+  depthFunc: (func: number) => void;
+  depthMask: (flag: boolean) => void;
+  depthRange: (zNear: number, zFar: number) => void;
+  detachShader: (program: WebGLProgram, shader: WebGLShader) => void;
+  disable: (cap: number) => void;
+  disableVertexAttribArray: (index: number) => void;
+  drawArrays: (mode: number, first: number, count: number) => void;
+  drawElements: (mode: number, count: number, type: number, offset: number) => void;
+  enable: (cap: number) => void;
+  enableVertexAttribArray: (index: number) => void;
+  finish: () => void;
+  flush: () => void;
+  framebufferRenderbuffer: (target: number, attachment: number, renderbuffertarget: number, renderbuffer: ?WebGLRenderbuffer) => void;
+  framebufferTexture2D: (target: number, attachment: number, textarget: number, texture: ?WebGLTexture, level: number) => void;
+  frontFace: (mode: number) => void;
+  generateMipmap: (target: number) => void;
+  getActiveAttrib: (program: WebGLProgram, index: number) => ?WebGLActiveInfo;
+  getActiveUniform: (program: WebGLProgram, index: number) => ?WebGLActiveInfo;
+  getAttachedShaders: (program: WebGLProgram) => ?Array<WebGLShader>;
+  getAttribLocation: (program: WebGLProgram, name: string) => number;
+  getBufferParameter: (target: number, pname: number) => any;
+  getParameter: (pname: number) => any;
+  getError: () => number;
+  getFramebufferAttachmentParameter: (target: number, attachment: number, pname: number) => any;
+  getProgramParameter: (program: WebGLProgram, pname: number) => any;
+  getProgramInfoLog: (program: WebGLProgram) => ?string;
+  getRenderbufferParameter: (target: number, pname: number) => any;
+  getShaderParameter: (shader: WebGLShader, pname: number) => any;
+  getShaderPrecisionFormat: (shadertype: number, precisiontype: number) => ?WebGLShaderPrecisionFormat;
+  getShaderInfoLog: (shader: WebGLShader) => ?string;
+  getShaderSource: (shader: WebGLShader) => ?string;
+  getTexParameter: (target: number, pname: number) => any;
+  getUniform: (program: WebGLProgram, location: WebGLUniformLocation) => any;
+  getUniformLocation: (program: WebGLProgram, name: string) => ?WebGLUniformLocation;
+  getVertexAttrib: (index: number, pname: number) => any;
+  getVertexAttribOffset: (index: number, pname: number) => number;
+  hint: (target: number, mode: number) => void;
+  isBuffer: (buffer: ?WebGLBuffer) => boolean;
+  isEnabled: (cap: number) => boolean;
+  isFramebuffer: (framebuffer: ?WebGLFramebuffer) => boolean;
+  isProgram: (program: ?WebGLProgram) => boolean;
+  isRenderbuffer: (renderbuffer: ?WebGLRenderbuffer) => boolean;
+  isShader: (shader: ?WebGLShader) => boolean;
+  isTexture: (texture: ?WebGLTexture) => boolean;
+  lineWidth: (width: number) => void;
+  linkProgram: (program: WebGLProgram) => void;
+  pixelStorei: (pname: number, param: number) => void;
+  polygonOffset: (factor: number, units: number) => void;
+  readPixels: (x: number, y: number, width: number, height: number, format: number, type: number, pixels: ?ArrayBufferView) => void;
+  renderbufferStorage: (target: number, internalformat: number, width: number, height: number) => void;
+  sampleCoverage: (value: number, invert: boolean) => void;
+  scissor: (x: number, y: number, width: number, height: number) => void;
+  shaderSource: (shader: WebGLShader, source: string) => void;
+  stencilFunc: (func: number, ref: number, mask: number) => void;
+  stencilFuncSeparate: (face: number, func: number, ref: number, mask: number) => void;
+  stencilMask: (mask: number) => void;
+  stencilMaskSeparate: (face: number, mask: number) => void;
+  stencilOp: (fail: number, zfail: number, zpass: number) => void;
+  stencilOpSeparate: (face: number, fail: number, zfail: number, zpass: number) => void;
+  texImage2D: (target: number, level: number, internalformat: number, width: number, height: number, border: number, format: number, type: number, pixels: ?ArrayBufferView) => void;
+  texImage2D: (target: number, level: number, internalformat: number, format: number, type: number, source: TexImageSource) => void;
+  texParameterf: (target: number, pname: number, param: number) => void;
+  texParameteri: (target: number, pname: number, param: number) => void;
+  texSubImage2D: (target: number, level: number, xoffset: number, yoffset: number, width: number, height: number, format: number, type: number, pixels: ?ArrayBufferView) => void;
+  texSubImage2D: (target: number, level: number, xoffset: number, yoffset: number, format: number, type: number, source: TexImageSource) => void;
+  uniform1f: (location: ?WebGLUniformLocation, x: number) => void;
+  uniform1fv: (location: ?WebGLUniformLocation, v: Float32Array) => void;
+  uniform1fv: (location: ?WebGLUniformLocation, v: Array<number>) => void;
+  uniform1i: (location: ?WebGLUniformLocation, x: number) => void;
+  uniform1iv: (location: ?WebGLUniformLocation, v: Int32Array) => void;
+  uniform1iv: (location: ?WebGLUniformLocation, v: Array<number>) => void;
+  uniform2f: (location: ?WebGLUniformLocation, x: number, y: number) => void;
+  uniform2fv: (location: ?WebGLUniformLocation, v: Float32Array) => void;
+  uniform2fv: (location: ?WebGLUniformLocation, v: Array<number>) => void;
+  uniform2i: (location: ?WebGLUniformLocation, x: number, y: number) => void;
+  uniform2iv: (location: ?WebGLUniformLocation, v: Int32Array) => void;
+  uniform2iv: (location: ?WebGLUniformLocation, v: Array<number>) => void;
+  uniform3f: (location: ?WebGLUniformLocation, x: number, y: number, z: number) => void;
+  uniform3fv: (location: ?WebGLUniformLocation, v: Float32Array) => void;
+  uniform3fv: (location: ?WebGLUniformLocation, v: Array<number>) => void;
+  uniform3i: (location: ?WebGLUniformLocation, x: number, y: number, z: number) => void;
+  uniform3iv: (location: ?WebGLUniformLocation, v: Int32Array) => void;
+  uniform3iv: (location: ?WebGLUniformLocation, v: Array<number>) => void;
+  uniform4f: (location: ?WebGLUniformLocation, x: number, y: number, z: number, w: number) => void;
+  uniform4fv: (location: ?WebGLUniformLocation, v: Float32Array) => void;
+  uniform4fv: (location: ?WebGLUniformLocation, v: Array<number>) => void;
+  uniform4i: (location: ?WebGLUniformLocation, x: number, y: number, z: number, w: number) => void;
+  uniform4iv: (location: ?WebGLUniformLocation, v: Int32Array) => void;
+  uniform4iv: (location: ?WebGLUniformLocation, v: Array<number>) => void;
+  uniformMatrix2fv: (location: ?WebGLUniformLocation, transpose: boolean, value: Float32Array) => void;
+  uniformMatrix2fv: (location: ?WebGLUniformLocation, transpose: boolean, value: Array<number>) => void;
+  uniformMatrix3fv: (location: ?WebGLUniformLocation, transpose: boolean, value: Float32Array) => void;
+  uniformMatrix3fv: (location: ?WebGLUniformLocation, transpose: boolean, value: Array<number>) => void;
+  uniformMatrix4fv: (location: ?WebGLUniformLocation, transpose: boolean, value: Float32Array) => void;
+  uniformMatrix4fv: (location: ?WebGLUniformLocation, transpose: boolean, value: Array<number>) => void;
+  useProgram: (program: ?WebGLProgram) => void;
+  validateProgram: (program: WebGLProgram) => void;
+  vertexAttrib1f: (index: number, x: number) => void;
+  vertexAttrib1fv: (index: number, values: VertexAttribFVSource) => void;
+  vertexAttrib2f: (index: number, x: number, y: number) => void;
+  vertexAttrib2fv: (index: number, values: VertexAttribFVSource) => void;
+  vertexAttrib3f: (index: number, x: number, y: number, z: number) => void;
+  vertexAttrib3fv: (index: number, values: VertexAttribFVSource) => void;
+  vertexAttrib4f: (index: number, x: number, y: number, z: number, w: number) => void;
+  vertexAttrib4fv: (index: number, values: VertexAttribFVSource) => void;
+  vertexAttribPointer: (index: number, size: number, type: number, normalized: boolean, stride: number, offset: number) => void;
+  viewport: (x: number, y: number, width: number, height: number) => void;
+}
+
+export default (gl: any): Context => {
+  const context: Context = Object.assign({}, gl, {
+  getContextAttributes () {
+    const res = gl.getContextAttributes();
+    return res;
+  },
+  isContextLost () {
+    const res = gl.isContextLost();
+    return res;
+  },
+  getSupportedExtensions () {
+    const res = gl.getSupportedExtensions();
+    return res;
+  },
+  getExtension (name) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'getExtension' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    const res = gl.getExtension(name);
+    return res;
+  },
+  activeTexture (texture) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'activeTexture' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    gl.activeTexture(texture);
+  },
+  attachShader (program, shader) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'attachShader' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    if (program!==null && !(program instanceof WebGLProgram)) throw new TypeError("Failed to execute 'attachShader' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLProgram'.");
+    if (shader!==null && !(shader instanceof WebGLShader)) throw new TypeError("Failed to execute 'attachShader' on 'WebGLRenderingContext': parameter 2 is not of type 'WebGLShader'.");
+    gl.attachShader(program._id, shader._id);
+  },
+  bindAttribLocation (program, index, name) {
+    if (arguments.length<3) throw new TypeError("Failed to execute 'bindAttribLocation' on 'WebGLRenderingContext': 3 arguments required, but only "+arguments.length+" present.");
+    if (program!==null && !(program instanceof WebGLProgram)) throw new TypeError("Failed to execute 'bindAttribLocation' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLProgram'.");
+    gl.bindAttribLocation(program._id, index, name);
+  },
+  bindBuffer (target, buffer) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'bindBuffer' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    if (buffer!==null && !(buffer instanceof WebGLBuffer)) throw new TypeError("Failed to execute 'bindBuffer' on 'WebGLRenderingContext': parameter 2 is not of type 'WebGLBuffer'.");
+    gl.bindBuffer(target, buffer===null ? null : buffer._id);
+  },
+  bindFramebuffer (target, framebuffer) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'bindFramebuffer' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    if (framebuffer!==null && !(framebuffer instanceof WebGLFramebuffer)) throw new TypeError("Failed to execute 'bindFramebuffer' on 'WebGLRenderingContext': parameter 2 is not of type 'WebGLFramebuffer'.");
+    gl.bindFramebuffer(target, framebuffer===null ? null : framebuffer._id);
+  },
+  bindRenderbuffer (target, renderbuffer) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'bindRenderbuffer' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    if (renderbuffer!==null && !(renderbuffer instanceof WebGLRenderbuffer)) throw new TypeError("Failed to execute 'bindRenderbuffer' on 'WebGLRenderingContext': parameter 2 is not of type 'WebGLRenderbuffer'.");
+    gl.bindRenderbuffer(target, renderbuffer===null ? null : renderbuffer._id);
+  },
+  bindTexture (target, texture) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'bindTexture' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    if (texture!==null && !(texture instanceof WebGLTexture)) throw new TypeError("Failed to execute 'bindTexture' on 'WebGLRenderingContext': parameter 2 is not of type 'WebGLTexture'.");
+    gl.bindTexture(target, texture===null ? null : texture._id);
+  },
+  blendColor (red, green, blue, alpha) {
+    if (arguments.length<4) throw new TypeError("Failed to execute 'blendColor' on 'WebGLRenderingContext': 4 arguments required, but only "+arguments.length+" present.");
+    gl.blendColor(red, green, blue, alpha);
+  },
+  blendEquation (mode) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'blendEquation' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    gl.blendEquation(mode);
+  },
+  blendEquationSeparate (modeRGB, modeAlpha) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'blendEquationSeparate' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    gl.blendEquationSeparate(modeRGB, modeAlpha);
+  },
+  blendFunc (sfactor, dfactor) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'blendFunc' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    gl.blendFunc(sfactor, dfactor);
+  },
+  blendFuncSeparate (srcRGB, dstRGB, srcAlpha, dstAlpha) {
+    if (arguments.length<4) throw new TypeError("Failed to execute 'blendFuncSeparate' on 'WebGLRenderingContext': 4 arguments required, but only "+arguments.length+" present.");
+    gl.blendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha);
+  },
+  bufferData (arg0, arg1, arg2) {
+    let signature;
+    switch (arguments.length) {
+    case 3:
+      if (typeof arg1 === "number")
+        signature = 0;
+      else if (arg1 instanceof ArrayBuffer)
+        signature = 1;
+      else if (arg1 instanceof ArrayBufferView)
+        signature = 2;
+      break;
+    }
+    if (arguments.length<3) throw new TypeError("Failed to execute 'bufferData' on 'WebGLRenderingContext': 3 arguments required, but only "+arguments.length+" present.");
+    switch (signature) {
+    case 0:
+    gl.bufferData(arg0, arg1, arg2);
+    break;
+    case 1:
+    gl.bufferData(arg0, arg1, arg2);
+    break;
+    case 2:
+    gl.bufferData(arg0, arg1, arg2);
+    break;
+   }
+  },
+  bufferSubData (target, offset, data) {
+    if (arguments.length<3) throw new TypeError("Failed to execute 'bufferSubData' on 'WebGLRenderingContext': 3 arguments required, but only "+arguments.length+" present.");
+    gl.bufferSubData(target, offset, data);
+  },
+  checkFramebufferStatus (target) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'checkFramebufferStatus' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    const res = gl.checkFramebufferStatus(target);
+    return res;
+  },
+  clear (mask) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'clear' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    gl.clear(mask);
+  },
+  clearColor (red, green, blue, alpha) {
+    if (arguments.length<4) throw new TypeError("Failed to execute 'clearColor' on 'WebGLRenderingContext': 4 arguments required, but only "+arguments.length+" present.");
+    gl.clearColor(red, green, blue, alpha);
+  },
+  clearDepth (depth) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'clearDepth' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    gl.clearDepth(depth);
+  },
+  clearStencil (s) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'clearStencil' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    gl.clearStencil(s);
+  },
+  colorMask (red, green, blue, alpha) {
+    if (arguments.length<4) throw new TypeError("Failed to execute 'colorMask' on 'WebGLRenderingContext': 4 arguments required, but only "+arguments.length+" present.");
+    gl.colorMask(red, green, blue, alpha);
+  },
+  compileShader (shader) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'compileShader' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    if (shader!==null && !(shader instanceof WebGLShader)) throw new TypeError("Failed to execute 'compileShader' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLShader'.");
+    gl.compileShader(shader._id);
+  },
+  compressedTexImage2D (target, level, internalformat, width, height, border, data) {
+    if (arguments.length<7) throw new TypeError("Failed to execute 'compressedTexImage2D' on 'WebGLRenderingContext': 7 arguments required, but only "+arguments.length+" present.");
+    gl.compressedTexImage2D(target, level, internalformat, width, height, border, data);
+  },
+  compressedTexSubImage2D (target, level, xoffset, yoffset, width, height, format, data) {
+    if (arguments.length<8) throw new TypeError("Failed to execute 'compressedTexSubImage2D' on 'WebGLRenderingContext': 8 arguments required, but only "+arguments.length+" present.");
+    gl.compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, data);
+  },
+  copyTexImage2D (target, level, internalformat, x, y, width, height, border) {
+    if (arguments.length<8) throw new TypeError("Failed to execute 'copyTexImage2D' on 'WebGLRenderingContext': 8 arguments required, but only "+arguments.length+" present.");
+    gl.copyTexImage2D(target, level, internalformat, x, y, width, height, border);
+  },
+  copyTexSubImage2D (target, level, xoffset, yoffset, x, y, width, height) {
+    if (arguments.length<8) throw new TypeError("Failed to execute 'copyTexSubImage2D' on 'WebGLRenderingContext': 8 arguments required, but only "+arguments.length+" present.");
+    gl.copyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height);
+  },
+  createBuffer () {
+    const res = gl.createBuffer();
+    return res===null ? null : new WebGLBuffer(res);
+  },
+  createFramebuffer () {
+    const res = gl.createFramebuffer();
+    return res===null ? null : new WebGLFramebuffer(res);
+  },
+  createProgram () {
+    const res = gl.createProgram();
+    return res===null ? null : new WebGLProgram(res);
+  },
+  createRenderbuffer () {
+    const res = gl.createRenderbuffer();
+    return res===null ? null : new WebGLRenderbuffer(res);
+  },
+  createShader (type) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'createShader' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    const res = gl.createShader(type);
+    return res===null ? null : new WebGLShader(res);
+  },
+  createTexture () {
+    const res = gl.createTexture();
+    return res===null ? null : new WebGLTexture(res);
+  },
+  cullFace (mode) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'cullFace' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    gl.cullFace(mode);
+  },
+  deleteBuffer (buffer) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'deleteBuffer' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    if (buffer!==null && !(buffer instanceof WebGLBuffer)) throw new TypeError("Failed to execute 'deleteBuffer' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLBuffer'.");
+    gl.deleteBuffer(buffer===null ? null : buffer._id);
+  },
+  deleteFramebuffer (framebuffer) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'deleteFramebuffer' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    if (framebuffer!==null && !(framebuffer instanceof WebGLFramebuffer)) throw new TypeError("Failed to execute 'deleteFramebuffer' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLFramebuffer'.");
+    gl.deleteFramebuffer(framebuffer===null ? null : framebuffer._id);
+  },
+  deleteProgram (program) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'deleteProgram' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    if (program!==null && !(program instanceof WebGLProgram)) throw new TypeError("Failed to execute 'deleteProgram' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLProgram'.");
+    gl.deleteProgram(program===null ? null : program._id);
+  },
+  deleteRenderbuffer (renderbuffer) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'deleteRenderbuffer' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    if (renderbuffer!==null && !(renderbuffer instanceof WebGLRenderbuffer)) throw new TypeError("Failed to execute 'deleteRenderbuffer' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLRenderbuffer'.");
+    gl.deleteRenderbuffer(renderbuffer===null ? null : renderbuffer._id);
+  },
+  deleteShader (shader) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'deleteShader' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    if (shader!==null && !(shader instanceof WebGLShader)) throw new TypeError("Failed to execute 'deleteShader' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLShader'.");
+    gl.deleteShader(shader===null ? null : shader._id);
+  },
+  deleteTexture (texture) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'deleteTexture' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    if (texture!==null && !(texture instanceof WebGLTexture)) throw new TypeError("Failed to execute 'deleteTexture' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLTexture'.");
+    gl.deleteTexture(texture===null ? null : texture._id);
+  },
+  depthFunc (func) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'depthFunc' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    gl.depthFunc(func);
+  },
+  depthMask (flag) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'depthMask' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    gl.depthMask(flag);
+  },
+  depthRange (zNear, zFar) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'depthRange' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    gl.depthRange(zNear, zFar);
+  },
+  detachShader (program, shader) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'detachShader' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    if (program!==null && !(program instanceof WebGLProgram)) throw new TypeError("Failed to execute 'detachShader' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLProgram'.");
+    if (shader!==null && !(shader instanceof WebGLShader)) throw new TypeError("Failed to execute 'detachShader' on 'WebGLRenderingContext': parameter 2 is not of type 'WebGLShader'.");
+    gl.detachShader(program._id, shader._id);
+  },
+  disable (cap) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'disable' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    gl.disable(cap);
+  },
+  disableVertexAttribArray (index) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'disableVertexAttribArray' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    gl.disableVertexAttribArray(index);
+  },
+  drawArrays (mode, first, count) {
+    if (arguments.length<3) throw new TypeError("Failed to execute 'drawArrays' on 'WebGLRenderingContext': 3 arguments required, but only "+arguments.length+" present.");
+    gl.drawArrays(mode, first, count);
+  },
+  drawElements (mode, count, type, offset) {
+    if (arguments.length<4) throw new TypeError("Failed to execute 'drawElements' on 'WebGLRenderingContext': 4 arguments required, but only "+arguments.length+" present.");
+    gl.drawElements(mode, count, type, offset);
+  },
+  enable (cap) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'enable' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    gl.enable(cap);
+  },
+  enableVertexAttribArray (index) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'enableVertexAttribArray' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    gl.enableVertexAttribArray(index);
+  },
+  finish () {
+    gl.finish();
+  },
+  flush () {
+    gl.flush();
+  },
+  framebufferRenderbuffer (target, attachment, renderbuffertarget, renderbuffer) {
+    if (arguments.length<4) throw new TypeError("Failed to execute 'framebufferRenderbuffer' on 'WebGLRenderingContext': 4 arguments required, but only "+arguments.length+" present.");
+    if (renderbuffer!==null && !(renderbuffer instanceof WebGLRenderbuffer)) throw new TypeError("Failed to execute 'framebufferRenderbuffer' on 'WebGLRenderingContext': parameter 4 is not of type 'WebGLRenderbuffer'.");
+    gl.framebufferRenderbuffer(target, attachment, renderbuffertarget, renderbuffer===null ? null : renderbuffer._id);
+  },
+  framebufferTexture2D (target, attachment, textarget, texture, level) {
+    if (arguments.length<5) throw new TypeError("Failed to execute 'framebufferTexture2D' on 'WebGLRenderingContext': 5 arguments required, but only "+arguments.length+" present.");
+    if (texture!==null && !(texture instanceof WebGLTexture)) throw new TypeError("Failed to execute 'framebufferTexture2D' on 'WebGLRenderingContext': parameter 4 is not of type 'WebGLTexture'.");
+    gl.framebufferTexture2D(target, attachment, textarget, texture===null ? null : texture._id, level);
+  },
+  frontFace (mode) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'frontFace' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    gl.frontFace(mode);
+  },
+  generateMipmap (target) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'generateMipmap' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    gl.generateMipmap(target);
+  },
+  getActiveAttrib (program, index) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'getActiveAttrib' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    if (program!==null && !(program instanceof WebGLProgram)) throw new TypeError("Failed to execute 'getActiveAttrib' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLProgram'.");
+    const res = gl.getActiveAttrib(program._id, index);
+    return res===null ? null : new WebGLActiveInfo(res);
+  },
+  getActiveUniform (program, index) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'getActiveUniform' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    if (program!==null && !(program instanceof WebGLProgram)) throw new TypeError("Failed to execute 'getActiveUniform' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLProgram'.");
+    const res = gl.getActiveUniform(program._id, index);
+    return res===null ? null : new WebGLActiveInfo(res);
+  },
+  getAttachedShaders (program) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'getAttachedShaders' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    if (program!==null && !(program instanceof WebGLProgram)) throw new TypeError("Failed to execute 'getAttachedShaders' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLProgram'.");
+    const res = gl.getAttachedShaders(program._id);
+    return res;
+  },
+  getAttribLocation (program, name) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'getAttribLocation' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    if (program!==null && !(program instanceof WebGLProgram)) throw new TypeError("Failed to execute 'getAttribLocation' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLProgram'.");
+    const res = gl.getAttribLocation(program._id, name);
+    return res;
+  },
+  getBufferParameter (target, pname) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'getBufferParameter' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    const res = gl.getBufferParameter(target, pname);
+    return res;
+  },
+  getParameter (pname) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'getParameter' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    const res = gl.getParameter(pname);
+    return res;
+  },
+  getError () {
+    const res = gl.getError();
+    return res;
+  },
+  getFramebufferAttachmentParameter (target, attachment, pname) {
+    if (arguments.length<3) throw new TypeError("Failed to execute 'getFramebufferAttachmentParameter' on 'WebGLRenderingContext': 3 arguments required, but only "+arguments.length+" present.");
+    const res = gl.getFramebufferAttachmentParameter(target, attachment, pname);
+    return res;
+  },
+  getProgramParameter (program, pname) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'getProgramParameter' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    if (program!==null && !(program instanceof WebGLProgram)) throw new TypeError("Failed to execute 'getProgramParameter' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLProgram'.");
+    const res = gl.getProgramParameter(program._id, pname);
+    return res;
+  },
+  getProgramInfoLog (program) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'getProgramInfoLog' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    if (program!==null && !(program instanceof WebGLProgram)) throw new TypeError("Failed to execute 'getProgramInfoLog' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLProgram'.");
+    const res = gl.getProgramInfoLog(program._id);
+    return res;
+  },
+  getRenderbufferParameter (target, pname) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'getRenderbufferParameter' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    const res = gl.getRenderbufferParameter(target, pname);
+    return res;
+  },
+  getShaderParameter (shader, pname) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'getShaderParameter' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    if (shader!==null && !(shader instanceof WebGLShader)) throw new TypeError("Failed to execute 'getShaderParameter' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLShader'.");
+    const res = gl.getShaderParameter(shader._id, pname);
+    return res;
+  },
+  getShaderPrecisionFormat (shadertype, precisiontype) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'getShaderPrecisionFormat' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    const res = gl.getShaderPrecisionFormat(shadertype, precisiontype);
+    return res===null ? null : new WebGLShaderPrecisionFormat(res);
+  },
+  getShaderInfoLog (shader) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'getShaderInfoLog' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    if (shader!==null && !(shader instanceof WebGLShader)) throw new TypeError("Failed to execute 'getShaderInfoLog' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLShader'.");
+    const res = gl.getShaderInfoLog(shader._id);
+    return res;
+  },
+  getShaderSource (shader) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'getShaderSource' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    if (shader!==null && !(shader instanceof WebGLShader)) throw new TypeError("Failed to execute 'getShaderSource' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLShader'.");
+    const res = gl.getShaderSource(shader._id);
+    return res;
+  },
+  getTexParameter (target, pname) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'getTexParameter' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    const res = gl.getTexParameter(target, pname);
+    return res;
+  },
+  getUniform (program, location) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'getUniform' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    if (program!==null && !(program instanceof WebGLProgram)) throw new TypeError("Failed to execute 'getUniform' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLProgram'.");
+    if (location!==null && !(location instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'getUniform' on 'WebGLRenderingContext': parameter 2 is not of type 'WebGLUniformLocation'.");
+    const res = gl.getUniform(program._id, location._id);
+    return res;
+  },
+  getUniformLocation (program, name) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'getUniformLocation' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    if (program!==null && !(program instanceof WebGLProgram)) throw new TypeError("Failed to execute 'getUniformLocation' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLProgram'.");
+    const res = gl.getUniformLocation(program._id, name);
+    return res===null ? null : new WebGLUniformLocation(res);
+  },
+  getVertexAttrib (index, pname) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'getVertexAttrib' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    const res = gl.getVertexAttrib(index, pname);
+    return res;
+  },
+  getVertexAttribOffset (index, pname) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'getVertexAttribOffset' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    const res = gl.getVertexAttribOffset(index, pname);
+    return res;
+  },
+  hint (target, mode) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'hint' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    gl.hint(target, mode);
+  },
+  isBuffer (buffer) { return buffer instanceof WebGLBuffer; },
+  isEnabled (cap) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'isEnabled' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    const res = gl.isEnabled(cap);
+    return res;
+  },
+  isFramebuffer (framebuffer) { return framebuffer instanceof WebGLFramebuffer; },
+  isProgram (program) { return program instanceof WebGLProgram; },
+  isRenderbuffer (renderbuffer) { return renderbuffer instanceof WebGLRenderbuffer; },
+  isShader (shader) { return shader instanceof WebGLShader; },
+  isTexture (texture) { return texture instanceof WebGLTexture; },
+  lineWidth (width) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'lineWidth' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    gl.lineWidth(width);
+  },
+  linkProgram (program) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'linkProgram' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    if (program!==null && !(program instanceof WebGLProgram)) throw new TypeError("Failed to execute 'linkProgram' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLProgram'.");
+    gl.linkProgram(program._id);
+  },
+  pixelStorei (pname, param) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'pixelStorei' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    gl.pixelStorei(pname, param);
+  },
+  polygonOffset (factor, units) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'polygonOffset' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    gl.polygonOffset(factor, units);
+  },
+  readPixels (x, y, width, height, format, type, pixels) {
+    if (arguments.length<7) throw new TypeError("Failed to execute 'readPixels' on 'WebGLRenderingContext': 7 arguments required, but only "+arguments.length+" present.");
+    gl.readPixels(x, y, width, height, format, type, pixels);
+  },
+  renderbufferStorage (target, internalformat, width, height) {
+    if (arguments.length<4) throw new TypeError("Failed to execute 'renderbufferStorage' on 'WebGLRenderingContext': 4 arguments required, but only "+arguments.length+" present.");
+    gl.renderbufferStorage(target, internalformat, width, height);
+  },
+  sampleCoverage (value, invert) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'sampleCoverage' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    gl.sampleCoverage(value, invert);
+  },
+  scissor (x, y, width, height) {
+    if (arguments.length<4) throw new TypeError("Failed to execute 'scissor' on 'WebGLRenderingContext': 4 arguments required, but only "+arguments.length+" present.");
+    gl.scissor(x, y, width, height);
+  },
+  shaderSource (shader, source) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'shaderSource' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    if (shader!==null && !(shader instanceof WebGLShader)) throw new TypeError("Failed to execute 'shaderSource' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLShader'.");
+    gl.shaderSource(shader._id, source);
+  },
+  stencilFunc (func, ref, mask) {
+    if (arguments.length<3) throw new TypeError("Failed to execute 'stencilFunc' on 'WebGLRenderingContext': 3 arguments required, but only "+arguments.length+" present.");
+    gl.stencilFunc(func, ref, mask);
+  },
+  stencilFuncSeparate (face, func, ref, mask) {
+    if (arguments.length<4) throw new TypeError("Failed to execute 'stencilFuncSeparate' on 'WebGLRenderingContext': 4 arguments required, but only "+arguments.length+" present.");
+    gl.stencilFuncSeparate(face, func, ref, mask);
+  },
+  stencilMask (mask) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'stencilMask' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    gl.stencilMask(mask);
+  },
+  stencilMaskSeparate (face, mask) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'stencilMaskSeparate' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    gl.stencilMaskSeparate(face, mask);
+  },
+  stencilOp (fail, zfail, zpass) {
+    if (arguments.length<3) throw new TypeError("Failed to execute 'stencilOp' on 'WebGLRenderingContext': 3 arguments required, but only "+arguments.length+" present.");
+    gl.stencilOp(fail, zfail, zpass);
+  },
+  stencilOpSeparate (face, fail, zfail, zpass) {
+    if (arguments.length<4) throw new TypeError("Failed to execute 'stencilOpSeparate' on 'WebGLRenderingContext': 4 arguments required, but only "+arguments.length+" present.");
+    gl.stencilOpSeparate(face, fail, zfail, zpass);
+  },
+  texImage2D (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) {
+    let signature;
+    switch (arguments.length) {
+    case 9:
+      signature = 0;
+      break;
+    case 6:
+      signature = 1;
+      break;
+    }
+    if ([6, 9].indexOf(arguments.length)===-1) throw new TypeError("Failed to execute 'texImage2D' on 'WebGLRenderingContext': Valid arities are : [6, 9], but "+arguments.length+" provided.");
+    switch (signature) {
+    case 0:
+    gl.texImage2D(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+    break;
+    case 1:
+    gl.texImage2D(arg0, arg1, arg2, arg3, arg4, arg5);
+    break;
+   }
+  },
+  texParameterf (target, pname, param) {
+    if (arguments.length<3) throw new TypeError("Failed to execute 'texParameterf' on 'WebGLRenderingContext': 3 arguments required, but only "+arguments.length+" present.");
+    gl.texParameterf(target, pname, param);
+  },
+  texParameteri (target, pname, param) {
+    if (arguments.length<3) throw new TypeError("Failed to execute 'texParameteri' on 'WebGLRenderingContext': 3 arguments required, but only "+arguments.length+" present.");
+    gl.texParameteri(target, pname, param);
+  },
+  texSubImage2D (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) {
+    let signature;
+    switch (arguments.length) {
+    case 9:
+      signature = 0;
+      break;
+    case 7:
+      signature = 1;
+      break;
+    }
+    if ([7, 9].indexOf(arguments.length)===-1) throw new TypeError("Failed to execute 'texSubImage2D' on 'WebGLRenderingContext': Valid arities are : [7, 9], but "+arguments.length+" provided.");
+    switch (signature) {
+    case 0:
+    gl.texSubImage2D(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+    break;
+    case 1:
+    gl.texSubImage2D(arg0, arg1, arg2, arg3, arg4, arg5, arg6);
+    break;
+   }
+  },
+  uniform1f (location, x) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'uniform1f' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    if (location!==null && !(location instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform1f' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform1f(location===null ? null : location._id, x);
+  },
+  uniform1fv (arg0, arg1) {
+    let signature;
+    switch (arguments.length) {
+    case 2:
+      if (arg1 instanceof Float32Array)
+        signature = 0;
+      else if (arg1 instanceof Array)
+        signature = 1;
+      break;
+    }
+    if (arguments.length<2) throw new TypeError("Failed to execute 'uniform1fv' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    switch (signature) {
+    case 0:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform1fv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform1fv(arg0===null ? null : arg0._id, arg1);
+    break;
+    case 1:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform1fv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform1fv(arg0===null ? null : arg0._id, new Float32Array(arg1));
+    break;
+   }
+  },
+  uniform1i (location, x) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'uniform1i' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    if (location!==null && !(location instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform1i' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform1i(location===null ? null : location._id, x);
+  },
+  uniform1iv (arg0, arg1) {
+    let signature;
+    switch (arguments.length) {
+    case 2:
+      if (arg1 instanceof Int32Array)
+        signature = 0;
+      else if (arg1 instanceof Array)
+        signature = 1;
+      break;
+    }
+    if (arguments.length<2) throw new TypeError("Failed to execute 'uniform1iv' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    switch (signature) {
+    case 0:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform1iv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform1iv(arg0===null ? null : arg0._id, arg1);
+    break;
+    case 1:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform1iv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform1iv(arg0===null ? null : arg0._id, new Int32Array(arg1));
+    break;
+   }
+  },
+  uniform2f (location, x, y) {
+    if (arguments.length<3) throw new TypeError("Failed to execute 'uniform2f' on 'WebGLRenderingContext': 3 arguments required, but only "+arguments.length+" present.");
+    if (location!==null && !(location instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform2f' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform2f(location===null ? null : location._id, x, y);
+  },
+  uniform2fv (arg0, arg1) {
+    let signature;
+    switch (arguments.length) {
+    case 2:
+      if (arg1 instanceof Float32Array)
+        signature = 0;
+      else if (arg1 instanceof Array)
+        signature = 1;
+      break;
+    }
+    if (arguments.length<2) throw new TypeError("Failed to execute 'uniform2fv' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    switch (signature) {
+    case 0:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform2fv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform2fv(arg0===null ? null : arg0._id, arg1);
+    break;
+    case 1:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform2fv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform2fv(arg0===null ? null : arg0._id, new Float32Array(arg1));
+    break;
+   }
+  },
+  uniform2i (location, x, y) {
+    if (arguments.length<3) throw new TypeError("Failed to execute 'uniform2i' on 'WebGLRenderingContext': 3 arguments required, but only "+arguments.length+" present.");
+    if (location!==null && !(location instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform2i' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform2i(location===null ? null : location._id, x, y);
+  },
+  uniform2iv (arg0, arg1) {
+    let signature;
+    switch (arguments.length) {
+    case 2:
+      if (arg1 instanceof Int32Array)
+        signature = 0;
+      else if (arg1 instanceof Array)
+        signature = 1;
+      break;
+    }
+    if (arguments.length<2) throw new TypeError("Failed to execute 'uniform2iv' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    switch (signature) {
+    case 0:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform2iv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform2iv(arg0===null ? null : arg0._id, arg1);
+    break;
+    case 1:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform2iv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform2iv(arg0===null ? null : arg0._id, new Int32Array(arg1));
+    break;
+   }
+  },
+  uniform3f (location, x, y, z) {
+    if (arguments.length<4) throw new TypeError("Failed to execute 'uniform3f' on 'WebGLRenderingContext': 4 arguments required, but only "+arguments.length+" present.");
+    if (location!==null && !(location instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform3f' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform3f(location===null ? null : location._id, x, y, z);
+  },
+  uniform3fv (arg0, arg1) {
+    let signature;
+    switch (arguments.length) {
+    case 2:
+      if (arg1 instanceof Float32Array)
+        signature = 0;
+      else if (arg1 instanceof Array)
+        signature = 1;
+      break;
+    }
+    if (arguments.length<2) throw new TypeError("Failed to execute 'uniform3fv' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    switch (signature) {
+    case 0:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform3fv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform3fv(arg0===null ? null : arg0._id, arg1);
+    break;
+    case 1:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform3fv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform3fv(arg0===null ? null : arg0._id, new Float32Array(arg1));
+    break;
+   }
+  },
+  uniform3i (location, x, y, z) {
+    if (arguments.length<4) throw new TypeError("Failed to execute 'uniform3i' on 'WebGLRenderingContext': 4 arguments required, but only "+arguments.length+" present.");
+    if (location!==null && !(location instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform3i' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform3i(location===null ? null : location._id, x, y, z);
+  },
+  uniform3iv (arg0, arg1) {
+    let signature;
+    switch (arguments.length) {
+    case 2:
+      if (arg1 instanceof Int32Array)
+        signature = 0;
+      else if (arg1 instanceof Array)
+        signature = 1;
+      break;
+    }
+    if (arguments.length<2) throw new TypeError("Failed to execute 'uniform3iv' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    switch (signature) {
+    case 0:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform3iv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform3iv(arg0===null ? null : arg0._id, arg1);
+    break;
+    case 1:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform3iv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform3iv(arg0===null ? null : arg0._id, new Int32Array(arg1));
+    break;
+   }
+  },
+  uniform4f (location, x, y, z, w) {
+    if (arguments.length<5) throw new TypeError("Failed to execute 'uniform4f' on 'WebGLRenderingContext': 5 arguments required, but only "+arguments.length+" present.");
+    if (location!==null && !(location instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform4f' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform4f(location===null ? null : location._id, x, y, z, w);
+  },
+  uniform4fv (arg0, arg1) {
+    let signature;
+    switch (arguments.length) {
+    case 2:
+      if (arg1 instanceof Float32Array)
+        signature = 0;
+      else if (arg1 instanceof Array)
+        signature = 1;
+      break;
+    }
+    if (arguments.length<2) throw new TypeError("Failed to execute 'uniform4fv' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    switch (signature) {
+    case 0:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform4fv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform4fv(arg0===null ? null : arg0._id, arg1);
+    break;
+    case 1:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform4fv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform4fv(arg0===null ? null : arg0._id, new Float32Array(arg1));
+    break;
+   }
+  },
+  uniform4i (location, x, y, z, w) {
+    if (arguments.length<5) throw new TypeError("Failed to execute 'uniform4i' on 'WebGLRenderingContext': 5 arguments required, but only "+arguments.length+" present.");
+    if (location!==null && !(location instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform4i' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform4i(location===null ? null : location._id, x, y, z, w);
+  },
+  uniform4iv (arg0, arg1) {
+    let signature;
+    switch (arguments.length) {
+    case 2:
+      if (arg1 instanceof Int32Array)
+        signature = 0;
+      else if (arg1 instanceof Array)
+        signature = 1;
+      break;
+    }
+    if (arguments.length<2) throw new TypeError("Failed to execute 'uniform4iv' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    switch (signature) {
+    case 0:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform4iv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform4iv(arg0===null ? null : arg0._id, arg1);
+    break;
+    case 1:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniform4iv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniform4iv(arg0===null ? null : arg0._id, new Int32Array(arg1));
+    break;
+   }
+  },
+  uniformMatrix2fv (arg0, arg1, arg2) {
+    let signature;
+    switch (arguments.length) {
+    case 3:
+      if (arg2 instanceof Float32Array)
+        signature = 0;
+      else if (arg2 instanceof Array)
+        signature = 1;
+      break;
+    }
+    if (arguments.length<3) throw new TypeError("Failed to execute 'uniformMatrix2fv' on 'WebGLRenderingContext': 3 arguments required, but only "+arguments.length+" present.");
+    switch (signature) {
+    case 0:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniformMatrix2fv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniformMatrix2fv(arg0===null ? null : arg0._id, arg1, arg2);
+    break;
+    case 1:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniformMatrix2fv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniformMatrix2fv(arg0===null ? null : arg0._id, arg1, new Float32Array(arg2));
+    break;
+   }
+  },
+  uniformMatrix3fv (arg0, arg1, arg2) {
+    let signature;
+    switch (arguments.length) {
+    case 3:
+      if (arg2 instanceof Float32Array)
+        signature = 0;
+      else if (arg2 instanceof Array)
+        signature = 1;
+      break;
+    }
+    if (arguments.length<3) throw new TypeError("Failed to execute 'uniformMatrix3fv' on 'WebGLRenderingContext': 3 arguments required, but only "+arguments.length+" present.");
+    switch (signature) {
+    case 0:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniformMatrix3fv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniformMatrix3fv(arg0===null ? null : arg0._id, arg1, arg2);
+    break;
+    case 1:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniformMatrix3fv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniformMatrix3fv(arg0===null ? null : arg0._id, arg1, new Float32Array(arg2));
+    break;
+   }
+  },
+  uniformMatrix4fv (arg0, arg1, arg2) {
+    let signature;
+    switch (arguments.length) {
+    case 3:
+      if (arg2 instanceof Float32Array)
+        signature = 0;
+      else if (arg2 instanceof Array)
+        signature = 1;
+      break;
+    }
+    if (arguments.length<3) throw new TypeError("Failed to execute 'uniformMatrix4fv' on 'WebGLRenderingContext': 3 arguments required, but only "+arguments.length+" present.");
+    switch (signature) {
+    case 0:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniformMatrix4fv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniformMatrix4fv(arg0===null ? null : arg0._id, arg1, arg2);
+    break;
+    case 1:
+    if (arg0!==null && !(arg0 instanceof WebGLUniformLocation)) throw new TypeError("Failed to execute 'uniformMatrix4fv' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLUniformLocation'.");
+    gl.uniformMatrix4fv(arg0===null ? null : arg0._id, arg1, new Float32Array(arg2));
+    break;
+   }
+  },
+  useProgram (program) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'useProgram' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    if (program!==null && !(program instanceof WebGLProgram)) throw new TypeError("Failed to execute 'useProgram' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLProgram'.");
+    gl.useProgram(program===null ? null : program._id);
+  },
+  validateProgram (program) {
+    if (arguments.length<1) throw new TypeError("Failed to execute 'validateProgram' on 'WebGLRenderingContext': 1 arguments required, but only "+arguments.length+" present.");
+    if (program!==null && !(program instanceof WebGLProgram)) throw new TypeError("Failed to execute 'validateProgram' on 'WebGLRenderingContext': parameter 1 is not of type 'WebGLProgram'.");
+    gl.validateProgram(program._id);
+  },
+  vertexAttrib1f (index, x) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'vertexAttrib1f' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    gl.vertexAttrib1f(index, x);
+  },
+  vertexAttrib1fv (index, values) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'vertexAttrib1fv' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    gl.vertexAttrib1fv(index, values);
+  },
+  vertexAttrib2f (index, x, y) {
+    if (arguments.length<3) throw new TypeError("Failed to execute 'vertexAttrib2f' on 'WebGLRenderingContext': 3 arguments required, but only "+arguments.length+" present.");
+    gl.vertexAttrib2f(index, x, y);
+  },
+  vertexAttrib2fv (index, values) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'vertexAttrib2fv' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    gl.vertexAttrib2fv(index, values);
+  },
+  vertexAttrib3f (index, x, y, z) {
+    if (arguments.length<4) throw new TypeError("Failed to execute 'vertexAttrib3f' on 'WebGLRenderingContext': 4 arguments required, but only "+arguments.length+" present.");
+    gl.vertexAttrib3f(index, x, y, z);
+  },
+  vertexAttrib3fv (index, values) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'vertexAttrib3fv' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    gl.vertexAttrib3fv(index, values);
+  },
+  vertexAttrib4f (index, x, y, z, w) {
+    if (arguments.length<5) throw new TypeError("Failed to execute 'vertexAttrib4f' on 'WebGLRenderingContext': 5 arguments required, but only "+arguments.length+" present.");
+    gl.vertexAttrib4f(index, x, y, z, w);
+  },
+  vertexAttrib4fv (index, values) {
+    if (arguments.length<2) throw new TypeError("Failed to execute 'vertexAttrib4fv' on 'WebGLRenderingContext': 2 arguments required, but only "+arguments.length+" present.");
+    gl.vertexAttrib4fv(index, values);
+  },
+  vertexAttribPointer (index, size, type, normalized, stride, offset) {
+    if (arguments.length<6) throw new TypeError("Failed to execute 'vertexAttribPointer' on 'WebGLRenderingContext': 6 arguments required, but only "+arguments.length+" present.");
+    gl.vertexAttribPointer(index, size, type, normalized, stride, offset);
+  },
+  viewport (x, y, width, height) {
+    if (arguments.length<4) throw new TypeError("Failed to execute 'viewport' on 'WebGLRenderingContext': 4 arguments required, but only "+arguments.length+" present.");
+    gl.viewport(x, y, width, height);
+  }
+});
+  if (Object.setPrototypeOf) {
+    Object.setPrototypeOf(context, global.WebGLRenderingContext.prototype);
+  } else {
+    // $FlowFixMe
+    context.__proto__ = global.WebGLRenderingContext.prototype;
+  }
+  return context;
+};


### PR DESCRIPTION
**PR STATUS: please don't merge yet. I still have something that breaks. app crashes, no idea why. but i'm close to something, I'll fix it soon.**

this is a better version of my PR https://github.com/exponent/exponent-sdk/pull/19 that i'll close later in favor of this one.

A tool script `glgenerator/genjs.js` takes the webgl.idl input and generates the file `src/generated/gl.js` that contains:

- generation of the WebGL classes (like WebGLBuffer)
- generation of flow types (first step, will add soon the the attrs / constants)
- for each WebGLContext method, wrapping the method so it:
  - validate arguments, trying to follow the exact same Chrome TypeError (there are probably remaining cases to validate, good for now)
  - wrap the arguments into correct types but provide to the implementation the underlying id (e.g. a instance of WebGLBuffer is provided, but inst._id integer is actually given to the native side)
  - support branching between different signature of a function. this was a bit tricky to implement, but it should work. the generated code is still readable.
